### PR TITLE
Fix issue with array_extensions breaking Hash[[]]

### DIFF
--- a/lib/rgen/array_extensions.rb
+++ b/lib/rgen/array_extensions.rb
@@ -10,7 +10,7 @@ class Array
 	end
 	
 	def method_missing(m, *args)
-		super unless size == 0 or compact.any?{|e| e.is_a? RGen::MetamodelBuilder::MMBase}
+		return super unless (size == 0 && m.to_s.start_with?('e')) or compact.any?{|e| e.is_a? RGen::MetamodelBuilder::MMBase}
 		# use an array to build the result to achiev similar ordering
 		result = []
 		inResult = {}


### PR DESCRIPTION
When the array_extensions is required it will mess up
expected behavior for expressions like `Hash[[]]` which should return
an empty hash. This is caused by method_missing logic always producing an empty
Array for any missing method (including `:to_hash`).

It is assumed that the implementation is there to provide access to the
various 'e' methods. This fix ensures that an empty array is only
produced for methods starting with 'e'.

It may not be accurate (there may be other methods), but it does
at least fix the `Hash[[]]` problem.
