### PR TITLE
Add ELong to the set of builtin types

### DIFF
--- a/lib/rgen/ecore/ecore.rb
+++ b/lib/rgen/ecore/ecore.rb
@@ -54,7 +54,7 @@ module RGen
         def defaultValue_derived
           return nil if defaultValueLiteral.nil?
           case eType
-            when EInt
+            when EInt, ELong
               defaultValueLiteral.to_i
             when EFloat
               defaultValueLiteral.to_f
@@ -181,6 +181,7 @@ module RGen
     
     EString = EDataType.new(:name => "EString", :instanceClassName => "String")
     EInt = EDataType.new(:name => "EInt", :instanceClassName => "Integer")
+    ELong = EDataType.new(:name => "ELong", :instanceClassName => "Long")
     EBoolean = EDataType.new(:name => "EBoolean", :instanceClassName => "Boolean")
     EFloat = EDataType.new(:name => "EFloat", :instanceClassName => "Float")
     ERubyObject = EDataType.new(:name => "ERubyObject", :instanceClassName => "Object")

--- a/lib/rgen/instantiator/ecore_xml_instantiator.rb
+++ b/lib/rgen/instantiator/ecore_xml_instantiator.rb
@@ -84,7 +84,7 @@ class ECoreXMLInstantiator < AbstractXMLInstantiator
     elsif eFeat
       value = true if value == "true" && eFeat.eType == EBoolean
       value = false if value == "false" && eFeat.eType == EBoolean
-      value = value.to_i if eFeat.eType == EInt
+      value = value.to_i if eFeat.eType == EInt || eFeat.eType == ELong
       @elementstack.last.setGeneric(attr, value)
     else
       log WARN, "Feature not found: #{attr} on #{@elementstack.last}"
@@ -134,6 +134,7 @@ class ECoreXMLInstantiator < AbstractXMLInstantiator
         case $1
           when "EString";     RGen::ECore::EString
           when "EInt";        RGen::ECore::EInt
+          when "ELong";       RGen::ECore::ELong
           when "EBoolean";    RGen::ECore::EBoolean
           when "EFloat";      RGen::ECore::EFloat
           when "EJavaObject"; RGen::ECore::EJavaObject

--- a/lib/rgen/instantiator/xmi11_instantiator.rb
+++ b/lib/rgen/instantiator/xmi11_instantiator.rb
@@ -116,7 +116,7 @@ class XMI11Instantiator < AbstractXMLInstantiator
         value = map_feature_value(attr_name, value) || value
         value = true if value == "true" && eFeat.eType == EBoolean
         value = false if value == "false" && eFeat.eType == EBoolean
-        value = value.to_i if eFeat.eType == EInt
+        value = value.to_i if eFeat.eType == EInt || eFeat.eType == ELong
         value = value.to_f if eFeat.eType == EFloat
         value = value.to_sym if eFeat.eType.is_a?(EEnum)
         @elementstack.last.setGeneric(attr_name, value)

--- a/lib/rgen/metamodel_builder/data_types.rb
+++ b/lib/rgen/metamodel_builder/data_types.rb
@@ -65,6 +65,9 @@ module DataTypes
 	# as possible values.
 	Boolean = Enum.new(:name => "Boolean", :literals => [true, false])
 
+	# Long represents a 64-bit Integer
+	class Long < Bignum
+	end
 end
 
 end

--- a/lib/rgen/metamodel_builder/intermediate/feature.rb
+++ b/lib/rgen/metamodel_builder/intermediate/feature.rb
@@ -67,6 +67,7 @@ class Attribute < Feature
   Types = { 
     String => :EString,
     Integer => :EInt,
+    RGen::MetamodelBuilder::DataTypes::Long => :ELong,
     Float => :EFloat,
     RGen::MetamodelBuilder::DataTypes::Boolean => :EBoolean,
     Object => :ERubyObject,

--- a/lib/rgen/serializer/xmi20_serializer.rb
+++ b/lib/rgen/serializer/xmi20_serializer.rb
@@ -57,6 +57,7 @@ class XMI20Serializer < XMLSerializer
     pre = "ecore:EDataType http://www.eclipse.org/emf/2002/Ecore"
     @referenceStrings[RGen::ECore::EString] = pre+"#//EString"
     @referenceStrings[RGen::ECore::EInt] = pre+"#//EInt"
+    @referenceStrings[RGen::ECore::ELong] = pre+"#//ELong"
     @referenceStrings[RGen::ECore::EFloat] = pre+"#//EFloat"
     @referenceStrings[RGen::ECore::EBoolean] = pre+"#//EBoolean"
     @referenceStrings[RGen::ECore::EJavaObject] = pre+"#//EJavaObject"

--- a/test/metamodel_roundtrip_test.rb
+++ b/test/metamodel_roundtrip_test.rb
@@ -65,8 +65,9 @@ class MetamodelRoundtripTest < Test::Unit::TestCase
       RGen::ECore::EClass.new(:name => "C1", :eStructuralFeatures => [
         RGen::ECore::EAttribute.new(:name => "a1", :eType => RGen::ECore::EString), 
         RGen::ECore::EAttribute.new(:name => "a2", :eType => RGen::ECore::EInt), 
-        RGen::ECore::EAttribute.new(:name => "a3", :eType => RGen::ECore::EFloat), 
-        RGen::ECore::EAttribute.new(:name => "a4", :eType => RGen::ECore::EBoolean) 
+        RGen::ECore::EAttribute.new(:name => "a3", :eType => RGen::ECore::ELong), 
+        RGen::ECore::EAttribute.new(:name => "a4", :eType => RGen::ECore::EFloat), 
+        RGen::ECore::EAttribute.new(:name => "a5", :eType => RGen::ECore::EBoolean) 
       ])
     ])
     outfile = TEST_DIR+"/using_builtin_types_serialized.ecore"
@@ -87,9 +88,11 @@ class MetamodelRoundtripTest < Test::Unit::TestCase
     a2 = env.find(:class => RGen::ECore::EAttribute, :name => "a2").first
     assert_equal(RGen::ECore::EInt, a2.eType)
     a3 = env.find(:class => RGen::ECore::EAttribute, :name => "a3").first
-    assert_equal(RGen::ECore::EFloat, a3.eType)
+    assert_equal(RGen::ECore::ELong, a3.eType)
     a4 = env.find(:class => RGen::ECore::EAttribute, :name => "a4").first
-    assert_equal(RGen::ECore::EBoolean, a4.eType)
+    assert_equal(RGen::ECore::EFloat, a4.eType)
+    a5 = env.find(:class => RGen::ECore::EAttribute, :name => "a5").first
+    assert_equal(RGen::ECore::EBoolean, a5.eType)
   end
 
 end

--- a/test/metamodel_roundtrip_test/using_builtin_types.ecore
+++ b/test/metamodel_roundtrip_test/using_builtin_types.ecore
@@ -2,7 +2,8 @@
   <eClassifiers name="C1" xsi:type="ecore:EClass">
     <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" xsi:type="ecore:EAttribute"/>
     <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a2" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt" xsi:type="ecore:EAttribute"/>
-    <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a3" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EFloat" xsi:type="ecore:EAttribute"/>
-    <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a4" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean" xsi:type="ecore:EAttribute"/>
+    <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a3" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//ELong" xsi:type="ecore:EAttribute"/>
+    <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a4" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EFloat" xsi:type="ecore:EAttribute"/>
+    <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a5" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean" xsi:type="ecore:EAttribute"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/test/xml_instantiator_test/simple_xmi_to_ecore.rb
+++ b/test/xml_instantiator_test/simple_xmi_to_ecore.rb
@@ -47,7 +47,7 @@ class SimpleXmiToECore < RGen::Transformer
   end
   
   transform SimpleXMIMetaModel::UML::Attribute, :to => EAttribute do
-    typemap = { "String" => EString, "boolean" => EBoolean, "int" => EInt, "float" => EFloat }
+    typemap = { "String" => EString, "boolean" => EBoolean, "int" => EInt, "long" => ELong, "float" => EFloat }
     tv = TaggedValueHelper.new(@current_object)
     {	:name => name, :eType => typemap[tv['type']],
       :eAnnotations => [ EAnnotation.new(:details => trans(modelElement_taggedValue.taggedValue)) ] }


### PR DESCRIPTION
The ELong is required to represent 64-bit quantities in languages
like Java, and also in Ruby when running on a 32-bit architecture.
