### PR TITLE
Use a value larger than Fixnum max to test Bignum support.

### DIFF
--- a/test/metamodel_builder_test.rb
+++ b/test/metamodel_builder_test.rb
@@ -268,8 +268,8 @@ class MetamodelBuilderTest < Test::Unit::TestCase
     sc = mm::SimpleClass.new
     sc.longWithDefault = 5
     assert_equal 5, sc.longWithDefault
-    sc.longWithDefault = 1234567890
-    assert_equal 1234567890, sc.longWithDefault
+    sc.longWithDefault = (2**(0.size * 8 -2) -1) + 1
+    assert_equal (2**(0.size * 8 -2) -1) + 1, sc.longWithDefault
     assert sc.longWithDefault.is_a?(Bignum)
     assert sc.longWithDefault.is_a?(Integer)
     err = assert_raise StandardError do


### PR DESCRIPTION
On 64 bit system the previous test value 1234567890 still fits in a Fixnum
so the tests will fail. Use a dynamically calculated value instead to ensure
that the value will force a Bignum in all cases.

Fixnum maximum calculation from
http://stackoverflow.com/questions/535721/ruby-max-integer
