### PR TITLE
Fixes issue #19.

### DIFF
--- a/lib/rgen/instantiator/default_xml_instantiator.rb
+++ b/lib/rgen/instantiator/default_xml_instantiator.rb
@@ -53,7 +53,7 @@ class DefaultXMLInstantiator < NodebasedXMLInstantiator
 		class_name = class_name(ns_desc.nil? ? node.qtag : ns_desc.prefix+node.tag)
 		mod = (ns_desc && ns_desc.target) || @default_module		
 		build_on_error(NameError, :build_class, class_name, mod) do
-			mod.const_get(class_name).new
+			mod.const_get(class_name, false).new
 		end
 	end
   


### PR DESCRIPTION
By setting the inherit flag to `false` on the `const_get` method, the use of the name `file` in an XML tag does not create a collision using the `DefaultXMLInstantiator`.