### PR TITLE
Improve generated addXXX and setXXX method performance

### DIFF
--- a/lib/rgen/metamodel_builder/builder_extensions.rb
+++ b/lib/rgen/metamodel_builder/builder_extensions.rb
@@ -395,7 +395,7 @@ module BuilderExtensions
     
         def add<%= firstToUpper(name) %>(val, index=-1)
           @<%= name %> = [] unless @<%= name %>
-          return if val.nil? || (val.is_a?(MMBase) || val.is_a?(MMGeneric)) && @<%= name %>.any? {|e| e.object_id == val.object_id}
+          return if val.nil? || (val.is_a?(MMBase) || val.is_a?(MMGeneric)) && @<%= name %>.any? {|e| e.equal?(val)}
           <%= type_check_code("val", props) %>
           @<%= name %>.insert(index, val)
           <% if other_role %>
@@ -409,7 +409,7 @@ module BuilderExtensions
         def remove<%= firstToUpper(name) %>(val)
           @<%= name %> = [] unless @<%= name %>
           @<%= name %>.each_with_index do |e,i|
-            if e.object_id == val.object_id
+            if e.equal?(val)
               @<%= name %>.delete_at(i)
               <% if props.reference? && props.value(:containment) %>
                 val._set_container(nil, nil)

--- a/lib/rgen/metamodel_builder/builder_extensions.rb
+++ b/lib/rgen/metamodel_builder/builder_extensions.rb
@@ -395,7 +395,7 @@ module BuilderExtensions
     
         def add<%= firstToUpper(name) %>(val, index=-1)
           @<%= name %> = [] unless @<%= name %>
-          return if val.nil? || (@<%= name %>.any?{|e| e.object_id == val.object_id} && (val.is_a?(MMBase) || val.is_a?(MMGeneric)))
+          return if val.nil? || (val.is_a?(MMBase) || val.is_a?(MMGeneric)) && @<%= name %>.any? {|e| e.object_id == val.object_id}
           <%= type_check_code("val", props) %>
           @<%= name %>.insert(index, val)
           <% if other_role %>

--- a/lib/rgen/metamodel_builder/builder_extensions.rb
+++ b/lib/rgen/metamodel_builder/builder_extensions.rb
@@ -428,9 +428,25 @@ module BuilderExtensions
           get<%= firstToUpper(name) %>.each {|e|
             remove<%= firstToUpper(name) %>(e)
           }
-          val.each {|v|
-            add<%= firstToUpper(name) %>(v)
+          @<%= name %> = [] unless @<%= name %>
+          <% if props.reference? %>
+          val.uniq {|elem| elem.object_id }.each {|elem|
+            next if elem.nil?
+            <%= type_check_code("elem", props) %>
+            @<%= name %> << elem
+            <% if other_role %>
+              elem._register<%= firstToUpper(other_role) %>(self) unless elem.is_a?(MMGeneric)
+            <% end %>
+            <% if props.value(:containment) %>
+              elem._set_container(self, :<%= name %>)
+            <% end %>
           }
+          <% else %>
+          val.each {|elem|
+            <%= type_check_code("elem", props) %>
+            @<%= name %> << elem
+         }
+         <% end %>
         end
         alias <%= name %>= set<%= firstToUpper(name) %>
         


### PR DESCRIPTION
The current implementation of the generated addXXX method will iterate
over the contained array where each iteration will then test for object_id
equality. Once the iteration is done and such an entry is found it
checks it the added value is an instance of MMBase or MMGeneric. If it
is, then it's considered a duplicate and the method returns.

This PR changes the implementation so that the test for MMBase/
MMGeneric is made prior to the iteration, thus avoiding the iteration
alltogether for all non model objects

The PR also changes the setXXX method to allow it to optimize the way
it ensures that the added elements are unique. Calling the addXXX method
to do an increasingly expensive sequential scan is very expensive when
large sets of values are assigned.