### PR TITLE
small fixes in ecore

### DIFF
--- a/Project.yaml
+++ b/Project.yaml
@@ -1,7 +1,7 @@
 name: rgen
 gemspec: rgen.gemspec
 git: https://github.com/mthiede/rgen.git
-version: 0.9.0
+version: 0.9.1
 summary: Ruby Modelling and Generator Framework
 email: martin dot thiede at gmx de
 homepage: http://ruby-gen.org

--- a/lib/rgen/ecore/ecore.rb
+++ b/lib/rgen/ecore/ecore.rb
@@ -25,7 +25,7 @@ module RGen
     
     class ENamedElement < EModelElement
       abstract
-      has_attr 'name', String
+      has_attr 'name', String, :lowerBound => 1
     end
     
     class ETypedElement < ENamedElement
@@ -148,8 +148,8 @@ module RGen
     end
     
     class EClass < EClassifier
-      has_attr 'abstract', Boolean
-      has_attr 'interface', Boolean
+      has_attr 'abstract', Boolean, :defaultValueLiteral => "false"
+      has_attr 'interface', Boolean, :defaultValueLiteral => "false"
       has_one  'eIDAttribute', ECore::EAttribute, :derived=>true, :resolveProxies=>false
       
       has_many 'eAllAttributes', ECore::EAttribute, :derived=>true

--- a/lib/rgen/ecore/ecore_to_json.rb
+++ b/lib/rgen/ecore/ecore_to_json.rb
@@ -134,8 +134,6 @@ def etypedelement(te)
     :unique => te.unique,
     :lowerBound => te.lowerBound,
     :upperBound => te.upperBound,
-    :many => te.many,
-    :required => te.required,
     :eType => {:_ref => te.eType ? ref_id(te.eType) : nil}
   })
 end

--- a/test/metamodel_roundtrip_test/using_builtin_types.ecore
+++ b/test/metamodel_roundtrip_test/using_builtin_types.ecore
@@ -1,5 +1,5 @@
 <ecore:EPackage name="P1" xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore">
-  <eClassifiers name="C1" xsi:type="ecore:EClass">
+  <eClassifiers abstract="false" interface="false" name="C1" xsi:type="ecore:EClass">
     <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" xsi:type="ecore:EAttribute"/>
     <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a2" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt" xsi:type="ecore:EAttribute"/>
     <eStructuralFeatures iD="false" changeable="true" derived="false" transient="false" unsettable="false" volatile="false" lowerBound="0" ordered="true" unique="true" upperBound="1" name="a3" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//ELong" xsi:type="ecore:EAttribute"/>


### PR DESCRIPTION
- [x] removed ETypedElement::{many, required} from ecore json serialization as they are derived features
- [x] set lower bound of ENamedElement::name & EClass::{abstract, interface} to 1
- [x] updated minor version of gem
- [ ] uploaded new gem to rubygems.org