### PR TITLE
Escape annotations in generated code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -242,3 +242,7 @@
 =0.10.2
 
 * Fixed issue with Kernel methods name clash with features
+
+=upcoming
+
+* properly escape annotations

--- a/lib/mmgen/templates/annotations.tpl
+++ b/lib/mmgen/templates/annotations.tpl
@@ -28,10 +28,10 @@
 	<% if source.nil? %>
 		<% expand 'Details' %>
 	<% else %>
-		:source => "<%= source.to_s %>", :details => {<% expand 'Details' %>}<%nows%>
+		:source => <%= source.to_s.dump %>, :details => {<% expand 'Details' %>}<%nows%>
 	<% end %>
 <% end %>
 
 <% define 'Details', :for => EAnnotation do %>
-	<%= details.sort{|a,b| a.key<=>b.key}.collect{ |d| "\'" + d.key + "\' => \'"+ (d.value || "").gsub('\'','\\\'').to_s + "\'"}.join(', ') %><%nows%>
+	<%= details.sort{|a,b| a.key<=>b.key}.collect{ |d| d.key.dump + " => " + (d.value || "").dump}.join(', ') %><%nows%>
 <% end %>


### PR DESCRIPTION
quote characters caused malformed generated code